### PR TITLE
Add Neon Drop game mode: shoot-up merge shooter with cascade mechanics

### DIFF
--- a/app/src/main/java/com/avfusionapps/game_2048/MainActivity.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.avfusionapps.game_2048.notification.ReminderManager
+import com.avfusionapps.game_2048.ui.screens.DropMergeScreen
 import com.avfusionapps.game_2048.ui.screens.GameScreen
 import com.avfusionapps.game_2048.ui.screens.GoogleAuthScreen
 import com.avfusionapps.game_2048.ui.screens.MainScreen
@@ -225,6 +226,9 @@ class MainActivity : ComponentActivity() {
                         }
                         composable("timeAttack") {
                             TimeAttackScreen(navController = navController)
+                        }
+                        composable("dropMerge") {
+                            DropMergeScreen(navController = navController)
                         }
                         composable(
                             route = "game?resume={resume}",

--- a/app/src/main/java/com/avfusionapps/game_2048/data/repository/DropMergeRepository.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/data/repository/DropMergeRepository.kt
@@ -1,0 +1,61 @@
+package com.avfusionapps.game_2048.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+
+private val Context.dropMergeDataStore: DataStore<Preferences> by preferencesDataStore(name = "drop_merge")
+
+/**
+ * Persistence for the Neon Drop mode: best score, best tile ever built and
+ * games played. Intentionally no currencies or consumables.
+ */
+class DropMergeRepository(private val context: Context) {
+
+    companion object {
+        val BEST_SCORE_KEY = intPreferencesKey("best_score")
+        val BEST_TILE_KEY = intPreferencesKey("best_tile")
+        val GAMES_PLAYED_KEY = intPreferencesKey("games_played")
+    }
+
+    val bestScore: Flow<Int> = context.dropMergeDataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences()) else throw exception
+        }
+        .map { preferences -> preferences[BEST_SCORE_KEY] ?: 0 }
+
+    val bestTile: Flow<Int> = context.dropMergeDataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences()) else throw exception
+        }
+        .map { preferences -> preferences[BEST_TILE_KEY] ?: 0 }
+
+    val gamesPlayed: Flow<Int> = context.dropMergeDataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences()) else throw exception
+        }
+        .map { preferences -> preferences[GAMES_PLAYED_KEY] ?: 0 }
+
+    suspend fun updateBests(score: Int, tile: Int) {
+        context.dropMergeDataStore.edit { preferences ->
+            val currentBestScore = preferences[BEST_SCORE_KEY] ?: 0
+            if (score > currentBestScore) preferences[BEST_SCORE_KEY] = score
+            val currentBestTile = preferences[BEST_TILE_KEY] ?: 0
+            if (tile > currentBestTile) preferences[BEST_TILE_KEY] = tile
+        }
+    }
+
+    suspend fun incrementGamesPlayed() {
+        context.dropMergeDataStore.edit { preferences ->
+            preferences[GAMES_PLAYED_KEY] = (preferences[GAMES_PLAYED_KEY] ?: 0) + 1
+        }
+    }
+}

--- a/app/src/main/java/com/avfusionapps/game_2048/game/DropMergeEngine.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/game/DropMergeEngine.kt
@@ -1,0 +1,231 @@
+package com.avfusionapps.game_2048.game
+
+import com.avfusionapps.game_2048.model.ConsumedTile
+import com.avfusionapps.game_2048.model.DropColumns
+import com.avfusionapps.game_2048.model.DropMergeConfig
+import com.avfusionapps.game_2048.model.DropShotResult
+import com.avfusionapps.game_2048.model.DropStep
+import com.avfusionapps.game_2048.model.DropStepKind
+import com.avfusionapps.game_2048.model.DropTile
+import kotlin.random.Random
+
+/**
+ * Pure rules engine for the Neon Drop mode. No Android dependencies — fully
+ * unit-testable. All randomness is injected through [random].
+ *
+ * Board convention (see DropMergeModels): columns hang from the top, row 0 is
+ * the ceiling, gravity pulls toward row 0. Because a column is a dense list,
+ * removing a tile collapses the stack automatically — list index IS the row.
+ */
+class DropMergeEngine(
+    private val random: Random = Random.Default,
+    startId: Long = 1L
+) {
+    private var nextId: Long = startId
+
+    fun freshTile(value: Int): DropTile = DropTile(id = nextId++, value = value)
+
+    // ─────────────────────────────── Spawning ───────────────────────────────
+
+    /**
+     * Smallest value the generator may spawn, driven by the best tile ever
+     * built: 512 → 4, 1024 → 8, 2048 → 16, … (below 512 the floor is 2).
+     * Tiles below this floor are also purged from the board when the floor rises.
+     */
+    fun minSpawnValue(bestTileEver: Int): Int =
+        if (bestTileEver >= DropMergeConfig.FIRST_PURGE_TRIGGER) {
+            1 shl (log2(bestTileEver) - 7)
+        } else 2
+
+    /** Weighted random spawn from a window of consecutive powers of two. */
+    fun spawnValue(bestTileEver: Int): Int {
+        val minExp = log2(minSpawnValue(bestTileEver))
+        val weights = DropMergeConfig.SPAWN_WEIGHTS
+        val total = weights.sum()
+        var pick = random.nextInt(total)
+        for (i in 0 until DropMergeConfig.SPAWN_WINDOW) {
+            pick -= weights[i]
+            if (pick < 0) return 1 shl (minExp + i)
+        }
+        return 1 shl minExp
+    }
+
+    /** Next milestone shown on the locked badge. */
+    fun unlockTarget(bestTileEver: Int): Int {
+        var target = DropMergeConfig.FIRST_UNLOCK_TARGET
+        while (target <= bestTileEver) target = target shl 1
+        return target
+    }
+
+    // ─────────────────────────────── Queries ────────────────────────────────
+
+    fun isColumnFull(columns: DropColumns, col: Int): Boolean =
+        columns[col].size >= DropMergeConfig.ROWS
+
+    /**
+     * Board is locked (game over) when every column is full and the current
+     * tile can't merge with any column end — every possible shot would be fatal.
+     */
+    fun isBoardLocked(columns: DropColumns, currentValue: Int): Boolean =
+        columns.all { it.size >= DropMergeConfig.ROWS } &&
+            columns.none { it.isNotEmpty() && it.last().value == currentValue }
+
+    // ─────────────────────────────── Resolution ─────────────────────────────
+
+    /**
+     * Resolve one shot of [tile] into [col]. Returns the animation steps
+     * (placement → merges/collapses → purges) and the score gained.
+     *
+     * Firing into a full column whose end tile doesn't match is an overflow →
+     * game over ([DropShotResult.overflow]); no steps are produced.
+     */
+    fun resolveShot(
+        columns: DropColumns,
+        col: Int,
+        tile: DropTile,
+        bestTileEver: Int
+    ): DropShotResult {
+        val full = isColumnFull(columns, col)
+        val matchesEnd = columns[col].isNotEmpty() && columns[col].last().value == tile.value
+        if (full && !matchesEnd) {
+            return DropShotResult(steps = emptyList(), totalGained = 0, maxChain = 0, overflow = true)
+        }
+
+        val cols = columns.map { it.toMutableList() }.toMutableList()
+        val steps = mutableListOf<DropStep>()
+        var runningBest = bestTileEver
+        var totalGained = 0
+        var chain = 0
+        var maxChain = 0
+
+        // 1) Placement. When the column is full-but-matching the tile briefly
+        //    sits one row past capacity and fuses on the very next step.
+        cols[col].add(tile)
+        steps += DropStep(columns = snapshot(cols), kind = DropStepKind.PLACE)
+
+        // 2) The landed tile merges first (genre rule: the action point may
+        //    fuse with up/left/right at once → ×2 / ×4 / ×8).
+        var focus: DropTile? = tile
+
+        while (true) {
+            // 2a) Cascade around the focus tile, then sweep the rest of the board.
+            while (true) {
+                val target = focus?.takeIf { findTile(cols, it.id) != null && hasEqualNeighbor(cols, it) }
+                    ?: findScanFocus(cols)
+                    ?: break
+
+                val (tCol, tRow) = findTile(cols, target.id)!!
+                val neighbors = equalNeighbors(cols, tCol, tRow)
+                val newValue = target.value shl neighbors.size
+                chain += 1
+                maxChain = maxOf(maxChain, chain)
+                totalGained += newValue
+
+                val consumed = neighbors.map { (nCol, nRow) ->
+                    ConsumedTile(
+                        tile = cols[nCol][nRow],
+                        fromCol = nCol, fromRow = nRow,
+                        toCol = tCol, toRow = tRow
+                    )
+                }
+                // Remove consumed tiles (per column, bottom-up so indices stay valid),
+                // then grow the focus tile in place. List removal = gravity collapse.
+                neighbors.groupBy { it.first }.forEach { (c, cells) ->
+                    cells.map { it.second }.sortedDescending().forEach { r -> cols[c].removeAt(r) }
+                }
+                val grown = target.copy(value = newValue)
+                replaceTile(cols, target.id, grown)
+
+                val unlocked = if (newValue >= unlockTarget(runningBest)) newValue else null
+                if (newValue > runningBest) runningBest = newValue
+
+                steps += DropStep(
+                    columns = snapshot(cols),
+                    kind = DropStepKind.MERGE,
+                    mergedTileId = grown.id,
+                    consumed = consumed,
+                    gained = newValue,
+                    chainIndex = chain,
+                    unlockedValue = unlocked
+                )
+                focus = grown
+            }
+
+            // 2b) Board is merge-stable — purge tiers below the spawn floor.
+            val floor = minSpawnValue(runningBest)
+            val purged = mutableListOf<ConsumedTile>()
+            for (c in cols.indices) {
+                for (r in cols[c].indices.reversed()) {
+                    if (cols[c][r].value < floor) {
+                        purged += ConsumedTile(cols[c][r], c, r, c, r)
+                        cols[c].removeAt(r)
+                    }
+                }
+            }
+            if (purged.isEmpty()) break
+
+            val purgeGained = purged.sumOf { it.tile.value }
+            totalGained += purgeGained
+            steps += DropStep(
+                columns = snapshot(cols),
+                kind = DropStepKind.PURGE,
+                consumed = purged,
+                gained = purgeGained,
+                chainIndex = chain
+            )
+            focus = null // collapse may open new merges — sweep again
+        }
+
+        return DropShotResult(steps, totalGained, maxChain, overflow = false)
+    }
+
+    // ─────────────────────────────── Internals ──────────────────────────────
+
+    /**
+     * Row-major scan (top→bottom, left→right) for the first tile with an equal
+     * orthogonal neighbor. Scanning this order makes the survivor of a vertical
+     * pair the UPPER tile (gravity side) and of a horizontal pair the LEFT one,
+     * and keeps resolution fully deterministic.
+     */
+    private fun findScanFocus(cols: List<List<DropTile>>): DropTile? {
+        val maxRows = cols.maxOf { it.size }
+        for (r in 0 until maxRows) {
+            for (c in cols.indices) {
+                val tile = cols[c].getOrNull(r) ?: continue
+                if (equalNeighbors(cols, c, r).isNotEmpty()) return tile
+            }
+        }
+        return null
+    }
+
+    private fun hasEqualNeighbor(cols: List<List<DropTile>>, tile: DropTile): Boolean {
+        val (c, r) = findTile(cols, tile.id) ?: return false
+        return equalNeighbors(cols, c, r).isNotEmpty()
+    }
+
+    /** Orthogonal (up/down/left/right) neighbors holding the same value. */
+    private fun equalNeighbors(cols: List<List<DropTile>>, col: Int, row: Int): List<Pair<Int, Int>> {
+        val value = cols[col][row].value
+        val candidates = listOf(col to row - 1, col to row + 1, col - 1 to row, col + 1 to row)
+        return candidates.filter { (c, r) ->
+            c in cols.indices && r >= 0 && cols[c].getOrNull(r)?.value == value
+        }
+    }
+
+    private fun findTile(cols: List<List<DropTile>>, id: Long): Pair<Int, Int>? {
+        for (c in cols.indices) {
+            val r = cols[c].indexOfFirst { it.id == id }
+            if (r >= 0) return c to r
+        }
+        return null
+    }
+
+    private fun replaceTile(cols: List<MutableList<DropTile>>, id: Long, newTile: DropTile) {
+        val (c, r) = findTile(cols, id) ?: return
+        cols[c][r] = newTile
+    }
+
+    private fun snapshot(cols: List<List<DropTile>>): DropColumns = cols.map { it.toList() }
+
+    private fun log2(value: Int): Int = 31 - Integer.numberOfLeadingZeros(value)
+}

--- a/app/src/main/java/com/avfusionapps/game_2048/model/DropMergeModels.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/model/DropMergeModels.kt
@@ -1,0 +1,112 @@
+package com.avfusionapps.game_2048.model
+
+/**
+ * Models for the Neon Drop (shoot-up merge) game mode.
+ *
+ * Board convention: 5 columns, each column is an ordered list of tiles whose
+ * index IS the row, with row 0 anchored at the TOP of the board. Gravity pulls
+ * tiles toward row 0 (the ceiling). New tiles land at row = column.size.
+ */
+
+/** A tile on the Neon Drop board. Stable [id] drives position/value animations. */
+data class DropTile(
+    val id: Long,
+    val value: Int
+)
+
+/** Board = 5 columns of stacked tiles, hanging from the top. */
+typealias DropColumns = List<List<DropTile>>
+
+/** Why a resolution step happened — lets the UI pick the right animation. */
+enum class DropStepKind { PLACE, MERGE, PURGE }
+
+/**
+ * One snapshot in a shot's resolution cascade. The UI animates tiles (by id)
+ * from the previous snapshot to this one.
+ *
+ * @param columns        full board state after this step
+ * @param kind           what happened in this step
+ * @param mergedTileId   tile that just grew (pop + glow it), if any
+ * @param consumed       tiles removed this step with the position they fly to / vanish at
+ * @param gained         score gained in this step
+ * @param chainIndex     0 for the landing, 1..n for cascade steps (drives COMBO text)
+ * @param unlockedValue  a brand-new max tile value first reached in this step, if any
+ */
+data class DropStep(
+    val columns: DropColumns,
+    val kind: DropStepKind,
+    val mergedTileId: Long? = null,
+    val consumed: List<ConsumedTile> = emptyList(),
+    val gained: Int = 0,
+    val chainIndex: Int = 0,
+    val unlockedValue: Int? = null
+)
+
+/** A tile removed during a step, with where it visually converges. */
+data class ConsumedTile(
+    val tile: DropTile,
+    val fromCol: Int,
+    val fromRow: Int,
+    val toCol: Int,
+    val toRow: Int
+)
+
+/** Result of resolving one shot. */
+data class DropShotResult(
+    val steps: List<DropStep>,
+    val totalGained: Int,
+    val maxChain: Int,
+    /** The shot overflowed a full, non-matching column → game over. */
+    val overflow: Boolean
+)
+
+/** Snapshot used for single-step undo. */
+data class DropUndoSnapshot(
+    val columns: DropColumns,
+    val score: Int,
+    val currentValue: Int,
+    val nextValue: Int,
+    val bestTileEver: Int
+)
+
+/** Full UI state for the Neon Drop screen. */
+data class DropMergeState(
+    val columns: DropColumns = List(DropMergeConfig.COLUMNS) { emptyList() },
+    val score: Int = 0,
+    val currentValue: Int = 2,
+    val nextValue: Int = 4,
+    /** Highest tile ever built across all games (drives spawn window + unlock badge). */
+    val bestTileEver: Int = 0,
+    /** Next milestone tile shown on the locked badge. */
+    val unlockTarget: Int = DropMergeConfig.FIRST_UNLOCK_TARGET,
+    val isGameOver: Boolean = false,
+    val isPaused: Boolean = false,
+    /** True while a shot's cascade is being played back — input is locked. */
+    val isResolving: Boolean = false,
+    val canUndo: Boolean = false,
+    val moveCount: Int = 0,
+    /* ---- transient, animation-facing fields (cleared as steps advance) ---- */
+    val lastStep: DropStep? = null,
+    val comboCount: Int = 0,
+    val justUnlockedValue: Int? = null
+)
+
+object DropMergeConfig {
+    const val COLUMNS = 5
+    const val ROWS = 8
+
+    /** Spawn window spans this many consecutive powers of two. */
+    const val SPAWN_WINDOW = 5
+
+    /** Weights for the spawn window, smallest value first. */
+    val SPAWN_WEIGHTS = intArrayOf(6, 5, 4, 2, 1)
+
+    /** First milestone shown as the locked badge target. */
+    const val FIRST_UNLOCK_TARGET = 256
+
+    /** Reaching this best tile starts purging the lowest tier (512 → purge 2s). */
+    const val FIRST_PURGE_TRIGGER = 512
+
+    /** A column with fewer than this many free cells is "in danger". */
+    const val DANGER_FREE_CELLS = 2
+}

--- a/app/src/main/java/com/avfusionapps/game_2048/ui/screens/DropMergeScreen.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/ui/screens/DropMergeScreen.kt
@@ -1,0 +1,834 @@
+package com.avfusionapps.game_2048.ui.screens
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.Undo
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.avfusionapps.game_2048.R
+import com.avfusionapps.game_2048.model.DropMergeConfig
+import com.avfusionapps.game_2048.model.DropStepKind
+import com.avfusionapps.game_2048.model.DropTile
+import com.avfusionapps.game_2048.ui.components.GameOverDialog
+import com.avfusionapps.game_2048.ui.components.GamePauseDialog
+import com.avfusionapps.game_2048.ui.components.GameScoreBoard
+import com.avfusionapps.game_2048.ui.components.NeonCard
+import com.avfusionapps.game_2048.ui.components.SquareIconButton
+import com.avfusionapps.game_2048.ui.theme.LocalGameTheme
+import com.avfusionapps.game_2048.utils.SoundManager
+import com.avfusionapps.game_2048.viewmodel.DropAnim
+import com.avfusionapps.game_2048.viewmodel.DropGameEvent
+import com.avfusionapps.game_2048.viewmodel.DropMergeViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+private const val COLS = DropMergeConfig.COLUMNS
+private const val ROWS = DropMergeConfig.ROWS
+
+@Composable
+fun DropMergeScreen(
+    navController: NavController,
+    viewModel: DropMergeViewModel = viewModel()
+) {
+    val theme = LocalGameTheme.current
+    val gameState by viewModel.gameState.collectAsState()
+    val bestScore by viewModel.bestScore.collectAsState(initial = 0)
+    val vibrationEnabled by viewModel.vibrationEnabled.collectAsState()
+    val soundEnabled by viewModel.soundEnabled.collectAsState()
+
+    val haptics = LocalHapticFeedback.current
+    val context = LocalContext.current
+    val soundManager = remember { SoundManager(context) }
+
+    // Sound + haptics from game events (respecting user settings).
+    LaunchedEffect(vibrationEnabled, soundEnabled) {
+        viewModel.events.collectLatest { event ->
+            if (vibrationEnabled) {
+                when (event) {
+                    DropGameEvent.MERGE, DropGameEvent.COMBO ->
+                        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    DropGameEvent.UNLOCK, DropGameEvent.PURGE, DropGameEvent.GAME_OVER ->
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    DropGameEvent.SHOOT -> Unit
+                }
+            }
+            if (soundEnabled) {
+                // SoundManager sleeps between tones — keep it off the main thread.
+                withContext(Dispatchers.Default) {
+                    when (event) {
+                        DropGameEvent.SHOOT -> soundManager.playSound(SoundManager.SOUND_MOVE)
+                        DropGameEvent.MERGE, DropGameEvent.COMBO, DropGameEvent.PURGE ->
+                            soundManager.playSound(SoundManager.SOUND_MERGE)
+                        DropGameEvent.UNLOCK -> soundManager.playSound(SoundManager.SOUND_LEVEL_UP)
+                        DropGameEvent.GAME_OVER -> soundManager.playSound(SoundManager.SOUND_GAME_OVER)
+                    }
+                }
+            }
+        }
+    }
+    androidx.compose.runtime.DisposableEffect(Unit) {
+        onDispose { soundManager.release() }
+    }
+
+    // Auto-dismiss the unlock banner.
+    LaunchedEffect(gameState.justUnlockedValue) {
+        if (gameState.justUnlockedValue != null) {
+            delay(1700)
+            viewModel.clearUnlockBanner()
+        }
+    }
+
+    BackHandler { viewModel.togglePause() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(theme.backgroundColor)
+            .safeDrawingPadding()
+            .testTag("DropMergeScreen_Root")
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(Modifier.height(8.dp))
+
+            // ── Top bar: back / score / next-unlock badge ──
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SquareIconButton(
+                    icon = Icons.AutoMirrored.Rounded.ArrowBack,
+                    contentDescription = stringResource(R.string.desc_back_button),
+                    onClick = { viewModel.setPaused(true) },
+                    modifier = Modifier.testTag("DropMerge_Button_Back")
+                )
+                Spacer(Modifier.width(10.dp))
+                GameScoreBoard(
+                    score = gameState.score,
+                    highScore = maxOf(bestScore, gameState.score),
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(Modifier.width(10.dp))
+                UnlockBadge(target = gameState.unlockTarget)
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            // ── Board + launcher ──
+            DropBoard(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                viewModel = viewModel,
+                gameStateProvider = { gameState }
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            // ── Bottom bar: undo / next preview / restart ──
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                SquareIconButton(
+                    icon = Icons.AutoMirrored.Rounded.Undo,
+                    contentDescription = stringResource(R.string.undo),
+                    onClick = { viewModel.undo() },
+                    tint = if (gameState.canUndo) theme.textColor else theme.textColor.copy(alpha = 0.3f),
+                    modifier = Modifier.testTag("DropMerge_Button_Undo")
+                )
+
+                NextTileChip(nextValue = gameState.nextValue)
+
+                SquareIconButton(
+                    icon = Icons.Rounded.Pause,
+                    contentDescription = stringResource(R.string.desc_pause_button),
+                    onClick = { viewModel.togglePause() },
+                    modifier = Modifier.testTag("DropMerge_Button_Pause")
+                )
+            }
+        }
+
+        // ── Unlock banner ──
+        AnimatedVisibility(
+            visible = gameState.justUnlockedValue != null,
+            enter = fadeIn() + scaleIn(initialScale = 0.7f),
+            exit = fadeOut() + scaleOut(targetScale = 0.9f),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 90.dp)
+        ) {
+            val unlockedValue = gameState.justUnlockedValue ?: 0
+            UnlockBanner(value = unlockedValue)
+        }
+    }
+
+    // ── Dialogs ──
+    if (gameState.isPaused && !gameState.isGameOver) {
+        GamePauseDialog(
+            currentScore = gameState.score,
+            onResume = { viewModel.setPaused(false) },
+            onRestart = {
+                viewModel.setPaused(false)
+                viewModel.startNewGame()
+            },
+            onQuit = {
+                viewModel.setPaused(false)
+                navController.popBackStack()
+            },
+            onDismiss = { viewModel.setPaused(false) }
+        )
+    }
+
+    if (gameState.isGameOver) {
+        GameOverDialog(
+            score = gameState.score,
+            onNewGame = { viewModel.startNewGame() },
+            onExit = { navController.popBackStack() }
+        )
+    }
+}
+
+// ─────────────────────────────────── Board ──────────────────────────────────
+
+@Composable
+private fun DropBoard(
+    modifier: Modifier,
+    viewModel: DropMergeViewModel,
+    gameStateProvider: () -> com.avfusionapps.game_2048.model.DropMergeState
+) {
+    val theme = LocalGameTheme.current
+    val gameState = gameStateProvider()
+    val density = LocalDensity.current
+
+    androidx.compose.foundation.layout.BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.TopCenter
+    ) {
+        // Geometry: 5 columns × 8 rows + a launcher strip below the board.
+        val gap = 4.dp
+        val launcherH = 84.dp
+        val cell: Dp = min(
+            ((maxWidth - gap * (COLS + 1)) / COLS).value,
+            ((maxHeight - launcherH - gap * (ROWS + 1)) / ROWS).value
+        ).dp
+        val boardW = cell * COLS + gap * (COLS + 1)
+        val boardH = cell * ROWS + gap * (ROWS + 1)
+
+        val cellPx = with(density) { cell.toPx() }
+        val gapPx = with(density) { gap.toPx() }
+        val boardHPx = with(density) { boardH.toPx() }
+
+        fun xOf(col: Int) = gapPx + col * (cellPx + gapPx)
+        fun yOf(row: Int) = gapPx + row * (cellPx + gapPx)
+        fun colFromX(x: Float): Int =
+            ((x - gapPx / 2f) / (cellPx + gapPx)).toInt().coerceIn(0, COLS - 1)
+
+        var aimCol by remember { mutableStateOf<Int?>(null) }
+        var lastShotCol by remember { mutableIntStateOf(COLS / 2) }
+
+        fun fire(col: Int) {
+            lastShotCol = col
+            viewModel.shoot(col)
+        }
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            // ── The board ──
+            Box(
+                modifier = Modifier
+                    .width(boardW)
+                    .height(boardH)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(theme.surfaceColor.copy(alpha = 0.55f))
+                    .pointerInput(gameState.isGameOver) {
+                        detectTapGestures { offset -> fire(colFromX(offset.x)) }
+                    }
+                    .pointerInput(gameState.isGameOver) {
+                        detectDragGestures(
+                            onDragStart = { offset -> aimCol = colFromX(offset.x) },
+                            onDrag = { change, _ -> aimCol = colFromX(change.position.x) },
+                            onDragEnd = {
+                                aimCol?.let { fire(it) }
+                                aimCol = null
+                            },
+                            onDragCancel = { aimCol = null }
+                        )
+                    }
+                    .testTag("DropMerge_Board")
+            ) {
+                // Column tracks with danger pulse.
+                for (c in 0 until COLS) {
+                    val fill = gameState.columns[c].size
+                    ColumnTrack(
+                        offsetX = with(density) { xOf(c).toDp() },
+                        width = cell,
+                        height = boardH - gap * 2,
+                        topPad = gap,
+                        danger = fill >= ROWS - DropMergeConfig.DANGER_FREE_CELLS,
+                        critical = fill >= ROWS,
+                        highlighted = aimCol == c
+                    )
+                }
+
+                // Ghost landing slot while aiming.
+                aimCol?.let { c ->
+                    val landRow = min(gameState.columns[c].size, ROWS - 1)
+                    GhostSlot(
+                        offset = IntOffset(xOf(c).roundToInt(), yOf(landRow).roundToInt()),
+                        size = cell,
+                        color = theme.accentColor
+                    )
+                }
+
+                // Live tiles — keyed by stable id so moves/merges animate.
+                gameState.columns.forEachIndexed { c, columnTiles ->
+                    columnTiles.forEachIndexed { r, tile ->
+                        key(tile.id) {
+                            BoardTileView(
+                                tile = tile,
+                                target = Offset(xOf(c), yOf(r)),
+                                spawn = Offset(xOf(c), boardHPx + cellPx * 0.4f),
+                                size = cell
+                            )
+                        }
+                    }
+                }
+
+                // Consumed tiles from the current step — fly into the merge
+                // target (MERGE) or shrink away in place (PURGE).
+                val step = gameState.lastStep
+                if (step != null && step.consumed.isNotEmpty()) {
+                    step.consumed.forEach { consumed ->
+                        key("ghost-${consumed.tile.id}") {
+                            ConsumedTileView(
+                                tile = consumed.tile,
+                                from = Offset(xOf(consumed.fromCol), yOf(consumed.fromRow)),
+                                to = Offset(xOf(consumed.toCol), yOf(consumed.toRow)),
+                                size = cell,
+                                purge = step.kind == DropStepKind.PURGE
+                            )
+                        }
+                    }
+                }
+
+                // Combo flair.
+                if (gameState.comboCount >= 2) {
+                    key(gameState.comboCount) {
+                        ComboText(
+                            combo = gameState.comboCount,
+                            modifier = Modifier.align(Alignment.TopCenter)
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            // ── Launcher ──
+            Launcher(
+                boardW = boardW,
+                cell = cell,
+                gap = gap,
+                currentValue = gameState.currentValue,
+                launcherCol = aimCol ?: lastShotCol,
+                enabled = !gameState.isResolving && !gameState.isGameOver && !gameState.isPaused,
+                onShoot = { fire(it) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnTrack(
+    offsetX: Dp,
+    width: Dp,
+    height: Dp,
+    topPad: Dp,
+    danger: Boolean,
+    critical: Boolean,
+    highlighted: Boolean
+) {
+    val theme = LocalGameTheme.current
+    val pulse = rememberInfiniteTransition(label = "dangerPulse")
+    val pulseAlpha by pulse.animateFloat(
+        initialValue = 0.25f,
+        targetValue = if (critical) 0.9f else 0.6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(if (critical) 380 else 650),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "dangerAlpha"
+    )
+
+    val borderColor = when {
+        danger -> theme.primaryColor.copy(alpha = pulseAlpha)
+        highlighted -> theme.accentColor.copy(alpha = 0.55f)
+        else -> theme.textColor.copy(alpha = 0.06f)
+    }
+
+    Box(
+        modifier = Modifier
+            .offset(x = offsetX, y = topPad)
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(10.dp))
+            .background(
+                if (highlighted) theme.accentColor.copy(alpha = 0.07f)
+                else theme.backgroundColor.copy(alpha = 0.45f)
+            )
+            .border(1.dp, borderColor, RoundedCornerShape(10.dp))
+    )
+}
+
+@Composable
+private fun GhostSlot(offset: IntOffset, size: Dp, color: Color) {
+    val pulse = rememberInfiniteTransition(label = "ghostPulse")
+    val alpha by pulse.animateFloat(
+        initialValue = 0.25f, targetValue = 0.65f,
+        animationSpec = infiniteRepeatable(tween(500), RepeatMode.Reverse),
+        label = "ghostAlpha"
+    )
+    Box(
+        modifier = Modifier
+            .offset { offset }
+            .size(size)
+            .clip(RoundedCornerShape(10.dp))
+            .border(2.dp, color.copy(alpha = alpha), RoundedCornerShape(10.dp))
+            .background(color.copy(alpha = alpha * 0.12f))
+    )
+}
+
+/** A live tile: animates position by id, pops + glows on value growth. */
+@Composable
+private fun BoardTileView(
+    tile: DropTile,
+    target: Offset,
+    spawn: Offset,
+    size: Dp
+) {
+    val theme = LocalGameTheme.current
+    val position = remember { Animatable(spawn, Offset.VectorConverter) }
+    val popScale = remember { Animatable(1f) }
+    val glowAlpha = remember { Animatable(0f) }
+    var lastValue by remember { mutableIntStateOf(tile.value) }
+
+    LaunchedEffect(target) {
+        position.animateTo(
+            target,
+            spring(dampingRatio = 0.62f, stiffness = Spring.StiffnessMediumLow)
+        )
+    }
+
+    LaunchedEffect(tile.value) {
+        if (tile.value != lastValue) {
+            lastValue = tile.value
+            launch {
+                popScale.snapTo(1.28f)
+                popScale.animateTo(1f, spring(dampingRatio = 0.45f, stiffness = Spring.StiffnessMedium))
+            }
+            launch {
+                glowAlpha.snapTo(0.85f)
+                glowAlpha.animateTo(0f, tween(DropAnim.MERGE_POP * 2, easing = LinearOutSlowInEasing))
+            }
+        }
+    }
+
+    val color = dropTileColor(theme, tile.value)
+    val glowColor = theme.accentColor
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(position.value.x.roundToInt(), position.value.y.roundToInt()) }
+            .size(size)
+            .scale(popScale.value)
+            .drawBehind {
+                if (glowAlpha.value > 0f) {
+                    drawCircle(
+                        brush = Brush.radialGradient(
+                            colors = listOf(glowColor.copy(alpha = glowAlpha.value), Color.Transparent)
+                        ),
+                        radius = this.size.maxDimension * 0.85f,
+                        center = center
+                    )
+                }
+            }
+            .clip(RoundedCornerShape(10.dp))
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(color, color.copy(alpha = 0.82f))
+                )
+            )
+            .border(1.dp, Color.White.copy(alpha = 0.18f), RoundedCornerShape(10.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        TileNumber(value = tile.value, cell = size, background = color)
+    }
+}
+
+/** A consumed tile ghost: flies into the merge target or purges in place. */
+@Composable
+private fun ConsumedTileView(
+    tile: DropTile,
+    from: Offset,
+    to: Offset,
+    size: Dp,
+    purge: Boolean
+) {
+    val theme = LocalGameTheme.current
+    val position = remember { Animatable(from, Offset.VectorConverter) }
+    val alpha = remember { Animatable(1f) }
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(Unit) {
+        launch {
+            if (!purge) position.animateTo(to, tween(DropAnim.CONSUME_FLY, easing = LinearOutSlowInEasing))
+        }
+        launch { alpha.animateTo(0f, tween(if (purge) DropAnim.MERGE_POP * 2 else DropAnim.CONSUME_FLY)) }
+        launch { scale.animateTo(if (purge) 0.1f else 0.6f, tween(if (purge) DropAnim.MERGE_POP * 2 else DropAnim.CONSUME_FLY)) }
+    }
+
+    val color = dropTileColor(theme, tile.value)
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(position.value.x.roundToInt(), position.value.y.roundToInt()) }
+            .size(size)
+            .scale(scale.value)
+            .alpha(alpha.value)
+            .clip(RoundedCornerShape(10.dp))
+            .background(color),
+        contentAlignment = Alignment.Center
+    ) {
+        TileNumber(value = tile.value, cell = size, background = color)
+    }
+}
+
+@Composable
+private fun TileNumber(value: Int, cell: Dp, background: Color) {
+    val textColor = if (background.luminance() > 0.55f) Color(0xFF1E1E2E) else Color.White
+    val digits = value.toString().length
+    val fontSize = when {
+        digits <= 2 -> cell.value * 0.42f
+        digits == 3 -> cell.value * 0.36f
+        else -> cell.value * 0.28f
+    }
+    Text(
+        text = value.toString(),
+        color = textColor,
+        fontSize = fontSize.sp,
+        fontWeight = FontWeight.ExtraBold
+    )
+}
+
+@Composable
+private fun ComboText(combo: Int, modifier: Modifier = Modifier) {
+    val theme = LocalGameTheme.current
+    val rise = remember { Animatable(0f) }
+    val alpha = remember { Animatable(1f) }
+    LaunchedEffect(Unit) {
+        launch { rise.animateTo(-38f, tween(750, easing = LinearOutSlowInEasing)) }
+        launch {
+            delay(420)
+            alpha.animateTo(0f, tween(330))
+        }
+    }
+    Text(
+        text = stringResource(R.string.drop_combo, combo),
+        color = theme.accentColor,
+        fontSize = 22.sp,
+        fontWeight = FontWeight.ExtraBold,
+        letterSpacing = 1.5.sp,
+        modifier = modifier
+            .padding(top = 46.dp)
+            .offset { IntOffset(0, rise.value.roundToInt()) }
+            .alpha(alpha.value)
+    )
+}
+
+// ───────────────────────────────── Launcher ─────────────────────────────────
+
+@Composable
+private fun Launcher(
+    boardW: Dp,
+    cell: Dp,
+    gap: Dp,
+    currentValue: Int,
+    launcherCol: Int,
+    enabled: Boolean,
+    onShoot: (Int) -> Unit
+) {
+    val theme = LocalGameTheme.current
+
+    // Idle bob on the loaded tile.
+    val bob = rememberInfiniteTransition(label = "launcherBob")
+    val bobY by bob.animateFloat(
+        initialValue = 0f, targetValue = -5f,
+        animationSpec = infiniteRepeatable(tween(700), RepeatMode.Reverse),
+        label = "bobY"
+    )
+
+    // Absolute placement so launcher slots line up exactly with board columns.
+    Box(
+        modifier = Modifier
+            .width(boardW)
+            .height(cell + 8.dp)
+    ) {
+        for (c in 0 until COLS) {
+            Box(
+                modifier = Modifier
+                    .offset(x = gap + (cell + gap) * c)
+                    .width(cell)
+                    .height(cell + 8.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(theme.surfaceColor.copy(alpha = 0.6f))
+                    .border(
+                        1.dp,
+                        if (c == launcherCol) theme.accentColor.copy(alpha = 0.5f)
+                        else theme.textColor.copy(alpha = 0.07f),
+                        RoundedCornerShape(10.dp)
+                    )
+                    .pointerInput(enabled) {
+                        detectTapGestures { if (enabled) onShoot(c) }
+                    }
+                    .testTag("DropMerge_LauncherSlot_$c"),
+                contentAlignment = Alignment.Center
+            ) {
+                if (c == launcherCol) {
+                    // The loaded tile rides on the aimed slot.
+                    val color = dropTileColor(theme, currentValue)
+                    Box(
+                        modifier = Modifier
+                            .offset { IntOffset(0, bobY.roundToInt()) }
+                            .size(cell * 0.92f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(
+                                Brush.verticalGradient(listOf(color, color.copy(alpha = 0.85f)))
+                            )
+                            .border(1.dp, Color.White.copy(alpha = 0.25f), RoundedCornerShape(10.dp))
+                            .alpha(if (enabled) 1f else 0.45f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        TileNumber(value = currentValue, cell = cell, background = color)
+                    }
+                } else {
+                    Icon(
+                        imageVector = Icons.Rounded.KeyboardArrowUp,
+                        contentDescription = null,
+                        tint = theme.textColor.copy(alpha = 0.25f),
+                        modifier = Modifier.size(cell * 0.4f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ───────────────────────────── Badges & banners ─────────────────────────────
+
+@Composable
+private fun UnlockBadge(target: Int) {
+    val theme = LocalGameTheme.current
+    val color = dropTileColor(theme, target)
+    NeonCard(
+        accentColor = color,
+        isSelected = false,
+        onClick = null,
+        cornerRadius = 12.dp
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(34.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(color.copy(alpha = 0.45f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = target.toString(),
+                    color = Color.White.copy(alpha = 0.9f),
+                    fontSize = if (target >= 1000) 9.sp else 12.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Spacer(Modifier.height(2.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Rounded.Lock,
+                    contentDescription = null,
+                    tint = theme.textColor.copy(alpha = 0.6f),
+                    modifier = Modifier.size(9.dp)
+                )
+                Spacer(Modifier.width(2.dp))
+                Text(
+                    text = stringResource(R.string.drop_locked),
+                    color = theme.textColor.copy(alpha = 0.6f),
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UnlockBanner(value: Int) {
+    val theme = LocalGameTheme.current
+    val color = dropTileColor(theme, value)
+    NeonCard(
+        accentColor = color,
+        isSelected = true,
+        onClick = null,
+        cornerRadius = 16.dp
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 22.dp, vertical = 14.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(9.dp))
+                    .background(Brush.verticalGradient(listOf(color, color.copy(alpha = 0.8f)))),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = value.toString(),
+                    color = Color.White,
+                    fontSize = if (value >= 1000) 10.sp else 14.sp,
+                    fontWeight = FontWeight.ExtraBold
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.drop_unlocked),
+                color = theme.textColor,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 1.5.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun NextTileChip(nextValue: Int) {
+    val theme = LocalGameTheme.current
+    val color = dropTileColor(theme, nextValue)
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = stringResource(R.string.drop_next),
+            color = theme.textColor.copy(alpha = 0.55f),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.sp
+        )
+        Spacer(Modifier.width(8.dp))
+        Box(
+            modifier = Modifier
+                .size(34.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Brush.verticalGradient(listOf(color, color.copy(alpha = 0.85f))))
+                .border(1.dp, Color.White.copy(alpha = 0.18f), RoundedCornerShape(8.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = nextValue.toString(),
+                color = if (color.luminance() > 0.55f) Color(0xFF1E1E2E) else Color.White,
+                fontSize = if (nextValue >= 100) 10.sp else 13.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+/** Theme color for a tile value; values above 2048 reuse the 2048 accent. */
+private fun dropTileColor(
+    theme: com.avfusionapps.game_2048.ui.theme.GameTheme,
+    value: Int
+): Color = theme.tileColors[value]
+    ?: theme.tileColors[2048]
+    ?: theme.primaryColor

--- a/app/src/main/java/com/avfusionapps/game_2048/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/ui/screens/MainScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Timer
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.SwipeUp
 import androidx.compose.material.icons.rounded.EmojiEvents
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -195,6 +196,9 @@ fun MainScreen(navController: NavController, viewModel: GameViewModel = viewMode
         onTimeAttackClick = {
             navController.navigate("timeAttack")
         },
+        onNeonDropClick = {
+            navController.navigate("dropMerge")
+        },
         onSettingsClick = {
             navController.navigate("themeSettings")
         },
@@ -299,6 +303,18 @@ fun MainScreen(navController: NavController, viewModel: GameViewModel = viewMode
                         .testTag("MainScreen_Button_TimeAttackMode")
                         .height(gameModeH)
                 )
+
+                GameModeCard(
+                    title = stringResource(R.string.neon_drop),
+                    subtitle = stringResource(R.string.neon_drop_subtitle),
+                    tagText = stringResource(R.string.neon_drop_tag),
+                    accentColor = theme.accentColor,
+                    icon = { size -> MainModeIcon(mode = MainModeIconType.NeonDrop, tint = theme.accentColor, size = size) },
+                    onClick = { navController.navigate("dropMerge") },
+                    modifier = Modifier
+                        .testTag("MainScreen_Button_NeonDropMode")
+                        .height(gameModeH)
+                )
             }
         }
     )
@@ -321,6 +337,7 @@ fun MainScreenContent(
     onResumeClick: () -> Unit = {},
     onStartClick: () -> Unit = {},
     onTimeAttackClick: () -> Unit = {},
+    onNeonDropClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
     actions: @Composable (ScreenDimensions) -> Unit
 ) {
@@ -728,6 +745,23 @@ fun MainScreenContent(
                             cardHeight = gameModeCardH,
                             modifier = Modifier.weight(1f)
                         )
+
+                        GameModeCardLandscape(
+                            title = "Neon Drop",
+                            subtitle = "Shoot tiles up to merge & chain!",
+                            accentColor = theme.accentColor,
+                            graphic = {
+                                Icon(
+                                    imageVector = Icons.Rounded.SwipeUp,
+                                    contentDescription = null,
+                                    tint = theme.accentColor,
+                                    modifier = Modifier.fillMaxSize(0.75f)
+                                )
+                            },
+                            onClick = onNeonDropClick,
+                            cardHeight = gameModeCardH,
+                            modifier = Modifier.weight(1f)
+                        )
                     }
 
                     // Tip of the Day
@@ -895,7 +929,7 @@ fun MainScreenContent(
     }
 }
 
-private enum class MainModeIconType { Classic, TimeAttack }
+private enum class MainModeIconType { Classic, TimeAttack, NeonDrop }
 
 @Composable
 private fun MainTopIconButton(
@@ -943,6 +977,7 @@ private fun MainModeIcon(
     val imageVector = when (mode) {
         MainModeIconType.Classic -> Icons.Rounded.GridView
         MainModeIconType.TimeAttack -> Icons.Rounded.Timer
+        MainModeIconType.NeonDrop -> Icons.Rounded.SwipeUp
     }
 
     Icon(

--- a/app/src/main/java/com/avfusionapps/game_2048/viewmodel/DropMergeViewModel.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/viewmodel/DropMergeViewModel.kt
@@ -1,0 +1,216 @@
+package com.avfusionapps.game_2048.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.avfusionapps.game_2048.data.GameSettingsRepository
+import com.avfusionapps.game_2048.data.repository.DropMergeRepository
+import com.avfusionapps.game_2048.game.DropMergeEngine
+import com.avfusionapps.game_2048.model.DropMergeConfig
+import com.avfusionapps.game_2048.model.DropMergeState
+import com.avfusionapps.game_2048.model.DropStepKind
+import com.avfusionapps.game_2048.model.DropUndoSnapshot
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/** Feedback events the screen turns into sound/haptics. */
+enum class DropGameEvent { SHOOT, MERGE, COMBO, PURGE, UNLOCK, GAME_OVER }
+
+/** Central timing knobs for the mode's playback + UI animations (millis). */
+object DropAnim {
+    const val SHOT_TRAVEL = 160L
+    const val MERGE_STEP = 210L
+    const val PURGE_STEP = 320L
+    const val TILE_MOVE = 180
+    const val MERGE_POP = 190
+    const val CONSUME_FLY = 160
+}
+
+class DropMergeViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = DropMergeRepository(application.applicationContext)
+    private val settingsRepository = GameSettingsRepository(application)
+    private val engine = DropMergeEngine()
+
+    private val _gameState = MutableStateFlow(DropMergeState())
+    val gameState: StateFlow<DropMergeState> = _gameState.asStateFlow()
+
+    val bestScore = repository.bestScore
+    val bestTile = repository.bestTile
+
+    val vibrationEnabled: StateFlow<Boolean> = settingsRepository.vibrationEnabledFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    val soundEnabled: StateFlow<Boolean> = settingsRepository.soundEnabledFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    private val _events = MutableSharedFlow<DropGameEvent>(
+        replay = 0,
+        extraBufferCapacity = 8,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val events: SharedFlow<DropGameEvent> = _events.asSharedFlow()
+
+    private var undoSnapshot: DropUndoSnapshot? = null
+    private var resolveJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            val persistedBestTile = repository.bestTile.first()
+            startNewGame(persistedBestTile)
+        }
+    }
+
+    fun startNewGame(persistedBestTile: Int? = null) {
+        resolveJob?.cancel()
+        undoSnapshot = null
+        val best = persistedBestTile ?: _gameState.value.bestTileEver
+        val current = engine.spawnValue(best)
+        val next = engine.spawnValue(best)
+        _gameState.value = DropMergeState(
+            currentValue = current,
+            nextValue = next,
+            bestTileEver = best,
+            unlockTarget = engine.unlockTarget(best)
+        )
+        viewModelScope.launch { repository.incrementGamesPlayed() }
+    }
+
+    fun togglePause() {
+        _gameState.value = _gameState.value.copy(isPaused = !_gameState.value.isPaused)
+    }
+
+    fun setPaused(paused: Boolean) {
+        _gameState.value = _gameState.value.copy(isPaused = paused)
+    }
+
+    /** Fire the current tile up [col]. Ignored while paused/over/animating. */
+    fun shoot(col: Int) {
+        val state = _gameState.value
+        if (state.isGameOver || state.isPaused || state.isResolving) return
+        if (col !in 0 until DropMergeConfig.COLUMNS) return
+
+        // A full, non-matching column is a fatal shot — resolve it as game over.
+        val tile = engine.freshTile(state.currentValue)
+        val result = engine.resolveShot(state.columns, col, tile, state.bestTileEver)
+
+        if (result.overflow) {
+            _gameState.value = state.copy(isGameOver = true, isResolving = false)
+            onGameOver()
+            return
+        }
+
+        undoSnapshot = DropUndoSnapshot(
+            columns = state.columns,
+            score = state.score,
+            currentValue = state.currentValue,
+            nextValue = state.nextValue,
+            bestTileEver = state.bestTileEver
+        )
+
+        resolveJob = viewModelScope.launch {
+            _events.tryEmit(DropGameEvent.SHOOT)
+            _gameState.value = state.copy(isResolving = true, canUndo = false, comboCount = 0)
+
+            var runningBest = state.bestTileEver
+            for (step in result.steps) {
+                step.unlockedValue?.let { runningBest = maxOf(runningBest, it) }
+                val maxOnBoard = step.columns.maxOf { c -> c.maxOfOrNull { it.value } ?: 0 }
+                runningBest = maxOf(runningBest, maxOnBoard)
+
+                _gameState.value = _gameState.value.copy(
+                    columns = step.columns,
+                    score = _gameState.value.score + step.gained,
+                    lastStep = step,
+                    comboCount = step.chainIndex,
+                    bestTileEver = runningBest,
+                    unlockTarget = engine.unlockTarget(runningBest),
+                    justUnlockedValue = step.unlockedValue ?: _gameState.value.justUnlockedValue
+                )
+
+                when (step.kind) {
+                    DropStepKind.PLACE -> delay(DropAnim.SHOT_TRAVEL)
+                    DropStepKind.MERGE -> {
+                        _events.tryEmit(if (step.chainIndex > 1) DropGameEvent.COMBO else DropGameEvent.MERGE)
+                        if (step.unlockedValue != null) _events.tryEmit(DropGameEvent.UNLOCK)
+                        delay(DropAnim.MERGE_STEP)
+                    }
+                    DropStepKind.PURGE -> {
+                        _events.tryEmit(DropGameEvent.PURGE)
+                        delay(DropAnim.PURGE_STEP)
+                    }
+                }
+            }
+
+            // Reload the launcher and settle the turn.
+            val newCurrent = _gameState.value.nextValue
+            val newNext = engine.spawnValue(runningBest)
+            val settled = _gameState.value.copy(
+                isResolving = false,
+                canUndo = true,
+                currentValue = newCurrent,
+                nextValue = newNext,
+                moveCount = _gameState.value.moveCount + 1,
+                lastStep = null
+            )
+            _gameState.value = settled
+
+            repository.updateBests(settled.score, runningBest)
+
+            if (engine.isBoardLocked(settled.columns, settled.currentValue)) {
+                _gameState.value = settled.copy(isGameOver = true)
+                onGameOver()
+            }
+        }
+    }
+
+    /** Single free undo of the last shot. */
+    fun undo() {
+        val snap = undoSnapshot ?: return
+        val state = _gameState.value
+        if (state.isResolving || state.isGameOver) return
+        undoSnapshot = null
+        _gameState.value = state.copy(
+            columns = snap.columns,
+            score = snap.score,
+            currentValue = snap.currentValue,
+            nextValue = snap.nextValue,
+            bestTileEver = snap.bestTileEver,
+            unlockTarget = engine.unlockTarget(snap.bestTileEver),
+            canUndo = false,
+            lastStep = null,
+            comboCount = 0
+        )
+    }
+
+    /** Called by the UI after the unlock banner finishes. */
+    fun clearUnlockBanner() {
+        if (_gameState.value.justUnlockedValue != null) {
+            _gameState.value = _gameState.value.copy(justUnlockedValue = null)
+        }
+    }
+
+    private fun onGameOver() {
+        _events.tryEmit(DropGameEvent.GAME_OVER)
+        val state = _gameState.value
+        viewModelScope.launch {
+            repository.updateBests(state.score, state.bestTileEver)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        resolveJob?.cancel()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,13 @@
     <string name="time_attack">TIME ATTACK</string>
     <string name="time_attack_subtitle">Beat the clock, chase high scores</string>
     <string name="time_attack_tag">⏱ 60 Seconds</string>
+    <string name="neon_drop">NEON DROP</string>
+    <string name="neon_drop_subtitle">Shoot tiles up, merge &amp; chain</string>
+    <string name="neon_drop_tag">⬆ Merge Shooter</string>
+    <string name="drop_next">NEXT</string>
+    <string name="drop_locked">Locked</string>
+    <string name="drop_unlocked">UNLOCKED!</string>
+    <string name="drop_combo">COMBO ×%1$d</string>
     <string name="best_score">BEST SCORE</string>
     <string name="continue_game">Continue</string>
     <string name="continue_game_subtitle">Pick up where\nyou left off</string>

--- a/app/src/test/java/com/avfusionapps/game_2048/DropMergeEngineTest.kt
+++ b/app/src/test/java/com/avfusionapps/game_2048/DropMergeEngineTest.kt
@@ -1,0 +1,237 @@
+package com.avfusionapps.game_2048
+
+import com.avfusionapps.game_2048.game.DropMergeEngine
+import com.avfusionapps.game_2048.model.DropMergeConfig
+import com.avfusionapps.game_2048.model.DropStepKind
+import com.avfusionapps.game_2048.model.DropTile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+/**
+ * Unit tests for the Neon Drop rules engine.
+ *
+ * Board convention reminder: row 0 = top (ceiling), gravity pulls toward
+ * row 0, a shot tile lands at row = column.size.
+ */
+class DropMergeEngineTest {
+
+    private fun engine() = DropMergeEngine(random = Random(42))
+
+    /** Builds a board from value lists (top → bottom per column). */
+    private fun board(vararg columns: List<Int>): List<List<DropTile>> {
+        var id = 1000L
+        val result = MutableList(DropMergeConfig.COLUMNS) { emptyList<DropTile>() }
+        columns.forEachIndexed { i, values ->
+            result[i] = values.map { DropTile(id = id++, value = it) }
+        }
+        return result
+    }
+
+    private fun values(columns: List<List<DropTile>>): List<List<Int>> =
+        columns.map { col -> col.map { it.value } }
+
+    // ── Placement ──
+
+    @Test
+    fun `shot into empty column lands at the top`() {
+        val e = engine()
+        val result = e.resolveShot(board(), col = 2, tile = e.freshTile(4), bestTileEver = 0)
+
+        assertFalse(result.overflow)
+        assertEquals(1, result.steps.size)
+        assertEquals(DropStepKind.PLACE, result.steps[0].kind)
+        assertEquals(listOf(4), values(result.steps.last().columns)[2])
+        assertEquals(0, result.totalGained)
+    }
+
+    @Test
+    fun `shot stacks below existing tiles`() {
+        val e = engine()
+        val start = board(listOf(8, 4))
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(2), bestTileEver = 0)
+
+        assertEquals(listOf(8, 4, 2), values(result.steps.last().columns)[0])
+    }
+
+    // ── Merging ──
+
+    @Test
+    fun `vertical merge cascades into the tile above`() {
+        val e = engine()
+        // Column: [8, 4]; shoot 4 → 4+4=8 at row 1, then 8+8=16 at row 0.
+        val start = board(listOf(8, 4))
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(4), bestTileEver = 0)
+
+        val final = values(result.steps.last().columns)
+        assertEquals(listOf(16), final[0])
+        assertEquals(8 + 16, result.totalGained)
+        assertEquals(2, result.maxChain)
+    }
+
+    @Test
+    fun `merging with two neighbors quadruples`() {
+        val e = engine()
+        // Columns 0 and 2 have a 4 at row 0; shoot 4 into empty column 1 →
+        // it lands at row 0 with equal left AND right neighbors → 4 × 2² = 16.
+        val start = board(listOf(4), emptyList(), listOf(4))
+        val result = e.resolveShot(start, col = 1, tile = e.freshTile(4), bestTileEver = 0)
+
+        val final = values(result.steps.last().columns)
+        assertEquals(emptyList<Int>(), final[0])
+        assertEquals(listOf(16), final[1])
+        assertEquals(emptyList<Int>(), final[2])
+        assertEquals(16, result.totalGained)
+    }
+
+    @Test
+    fun `gravity collapses columns after a side merge`() {
+        val e = engine()
+        // Column 0: [8, 2]; column 1: empty. Shoot 8 into column 1: it lands at
+        // row 0 next to the 8 → merges to 16; the 2 in column 0 slides up.
+        val start = board(listOf(8, 2))
+        val result = e.resolveShot(start, col = 1, tile = e.freshTile(8), bestTileEver = 0)
+
+        val final = values(result.steps.last().columns)
+        assertEquals(listOf(2), final[0])
+        assertEquals(listOf(16), final[1])
+    }
+
+    @Test
+    fun `chain triggered by gravity collapse`() {
+        val e = engine()
+        // Column 0: [4, 2, 2]. Shoot 2 → bottom pair 2+2=4 at row 2... then
+        // collapse: [4, 2, 4]? No: shoot 2 lands at row 3, merges with the 2
+        // above (row 2) → grows to 4 at row 2 → column [4, 2, 4] — the grown 4
+        // is not adjacent to the top 4, so it stays. Verify exactly that.
+        val start = board(listOf(4, 2, 2))
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(2), bestTileEver = 0)
+
+        val final = values(result.steps.last().columns)
+        assertEquals(listOf(4, 2, 4), final[0])
+        assertEquals(4, result.totalGained)
+    }
+
+    // ── Overflow & lock ──
+
+    @Test
+    fun `shot into full non-matching column overflows`() {
+        val e = engine()
+        val fullColumn = List(DropMergeConfig.ROWS) { 1 shl (it % 3 + 1) } // 2,4,8,...
+        val start = board(fullColumn)
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(64), bestTileEver = 0)
+
+        assertTrue(result.overflow)
+        assertTrue(result.steps.isEmpty())
+    }
+
+    @Test
+    fun `shot into full column with matching end merges instead of overflowing`() {
+        val e = engine()
+        // 8 slots ending in 4: 256,128,64,32,16,8,2,4
+        val start = board(listOf(256, 128, 64, 32, 16, 8, 2, 4))
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(4), bestTileEver = 0)
+
+        assertFalse(result.overflow)
+        val final = values(result.steps.last().columns)
+        assertEquals(listOf(256, 128, 64, 32, 16, 8, 2, 8), final[0])
+    }
+
+    @Test
+    fun `board locked only when all columns full and no end matches`() {
+        val e = engine()
+        val full = List(DropMergeConfig.ROWS) { 1 shl (it + 1) } // ends at 256
+        val allFull = board(full, full, full, full, full)
+
+        assertTrue(e.isBoardLocked(allFull, currentValue = 4))
+        assertFalse(e.isBoardLocked(allFull, currentValue = 256)) // end tile matches
+        val oneFree = board(full, full, full, full, emptyList())
+        assertFalse(e.isBoardLocked(oneFree, currentValue = 4))
+    }
+
+    // ── Spawning, milestones, purge ──
+
+    @Test
+    fun `spawn floor rises with best tile`() {
+        val e = engine()
+        assertEquals(2, e.minSpawnValue(0))
+        assertEquals(2, e.minSpawnValue(256))
+        assertEquals(4, e.minSpawnValue(512))
+        assertEquals(8, e.minSpawnValue(1024))
+        assertEquals(16, e.minSpawnValue(2048))
+    }
+
+    @Test
+    fun `spawn values stay inside the window`() {
+        val e = engine()
+        repeat(500) {
+            val v = e.spawnValue(bestTileEver = 0)
+            assertTrue("spawned $v", v in listOf(2, 4, 8, 16, 32))
+        }
+        repeat(500) {
+            val v = e.spawnValue(bestTileEver = 1024)
+            assertTrue("spawned $v", v in listOf(8, 16, 32, 64, 128))
+        }
+    }
+
+    @Test
+    fun `unlock target is next power above best`() {
+        val e = engine()
+        assertEquals(256, e.unlockTarget(0))
+        assertEquals(256, e.unlockTarget(128))
+        assertEquals(512, e.unlockTarget(256))
+        assertEquals(1024, e.unlockTarget(512))
+    }
+
+    @Test
+    fun `reaching a milestone flags the step as unlocked`() {
+        val e = engine()
+        // 128 + 128 = 256 = first unlock target.
+        val start = board(listOf(128))
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(128), bestTileEver = 128)
+
+        val mergeStep = result.steps.first { it.kind == DropStepKind.MERGE }
+        assertEquals(256, mergeStep.unlockedValue)
+    }
+
+    @Test
+    fun `crossing 512 purges all twos and credits their score`() {
+        val e = engine()
+        // Column 0: [256, 256-to-be]: shoot 256 onto 256 → 512. 2s elsewhere purge.
+        val start = board(listOf(256), listOf(2, 4), listOf(8, 2))
+        val result = e.resolveShot(start, col = 0, tile = e.freshTile(256), bestTileEver = 256)
+
+        val purgeStep = result.steps.firstOrNull { it.kind == DropStepKind.PURGE }
+        assertTrue("expected a purge step", purgeStep != null)
+        assertEquals(2, purgeStep!!.consumed.size)
+
+        val final = values(result.steps.last().columns)
+        assertEquals(listOf(512), final[0])
+        assertEquals(listOf(4), final[1])
+        assertEquals(listOf(8), final[2])
+        assertEquals(512 + 2 + 2, result.totalGained)
+    }
+
+    @Test
+    fun `no purge below the 512 threshold`() {
+        val e = engine()
+        val start = board(listOf(2), listOf(2, 4))
+        val result = e.resolveShot(start, col = 3, tile = e.freshTile(8), bestTileEver = 256)
+
+        assertTrue(result.steps.none { it.kind == DropStepKind.PURGE })
+    }
+
+    @Test
+    fun `tile ids are stable through merges`() {
+        val e = engine()
+        val start = board(listOf(8, 4))
+        val shot = e.freshTile(4)
+        val result = e.resolveShot(start, col = 0, tile = shot, bestTileEver = 0)
+
+        // The shot tile is the merge survivor of the first merge (grows in place).
+        val firstMerge = result.steps.first { it.kind == DropStepKind.MERGE }
+        assertEquals(shot.id, firstMerge.mergedTileId)
+    }
+}

--- a/docs/NEON_DROP_MECHANICS.md
+++ b/docs/NEON_DROP_MECHANICS.md
@@ -1,0 +1,150 @@
+# Neon Drop — Game Mechanics Specification
+
+A shoot-up number-merge mode (X2-Blocks style) for the Neon 2048 app.
+No coins, no boosters, no shop, no ads — pure mechanics, physics-feel animation,
+fully themed through `GameTheme`.
+
+---
+
+## 1. Board
+
+| Property | Value |
+|----------|-------|
+| Columns  | 5 |
+| Rows     | 8 (capacity per column) |
+| Anchor   | Stacks hang from the **top** of the board |
+| Gravity  | Toward the **ceiling** (row 0). Removing a tile makes tiles below it slide up |
+| Launcher | Bottom of the screen, fires tiles **upward** |
+
+Cell addressing: `(col, row)` with `row 0` at the top. A column is an ordered
+list of tiles; index = row. New tiles land at `row = column.size`.
+
+## 2. Tiles
+
+- Values are powers of two: 2, 4, 8, … (no cap; colors cycle above 2048).
+- Every tile has a **stable id** — the UI animates position/value changes by id,
+  which is what makes movement, collapse and merges look continuous.
+- Colors come from `GameTheme.tileColors[value]`, so every app theme skins the
+  mode automatically. Values above 2048 reuse the 2048 accent.
+
+## 3. Shooting
+
+1. The launcher holds the **current** tile; a small preview shows the **next** tile.
+2. Aim by tapping a column, or dragging horizontally across the board/launcher —
+   the hovered column highlights and a **ghost slot** shows the exact landing cell.
+3. On release/tap the tile flies up the column (~160 ms, ease-out) and lands with
+   a squash-and-settle impact.
+4. Input is locked while a resolution (merge cascade) is playing (~short); the
+   launcher reloads from the spawn generator when the board settles.
+
+## 4. Merging
+
+When a tile lands (or the board changes), merges resolve as a cascade:
+
+- A tile merges with **every orthogonally adjacent tile of equal value**
+  (above, below, left, right — within stacks).
+- Merging with `n` neighbors simultaneously: `newValue = value × 2^n`
+  - 1 neighbor → ×2 (classic)
+  - 2 neighbors → ×4
+  - 3 neighbors → ×8
+- Neighbor tiles are **consumed** — they fly into the focus tile, which pops to
+  the new value with a glow burst.
+- After each merge, **gravity** collapses affected columns toward the ceiling,
+  then the board is re-scanned; any new adjacency triggers the next chain step.
+- The cascade repeats until the board is stable.
+
+### Determinism
+The scan order for follow-up merges is fixed (left→right, top→bottom, placed
+tile first), so identical inputs always resolve identically — this keeps undo,
+tests and animation playback exact.
+
+## 5. Scoring & combos
+
+- Every merge adds `newValue` to the score (2048-style, predictable).
+- Each extra cascade step shows **COMBO ×N** floating text; combos are a
+  celebration, not a hidden multiplier — score stays honest and readable.
+- **Best score** and **best tile** persist via DataStore (`drop_merge` prefs).
+
+## 6. Spawn generator
+
+- Spawn window = **5 consecutive powers of two**, weighted toward the small end
+  (weights 6/5/4/2/1), starting at 2…32.
+- The window floor rises with your **best tile ever** (see purge below), so
+  late-game boards aren't littered with useless 2s.
+- The generator never spawns the next-unlock value directly — you must build it.
+
+## 7. Milestones & the purge
+
+- A badge shows the **next unlock** target (first target: 256), greyed until reached.
+- Reaching a new max tile fires an **UNLOCKED** banner + glow celebration.
+- **Purge:** when the best tile reaches a threshold, the lowest tier detonates
+  off the board (with score credit for each removed tile) and leaves the spawn pool:
+
+| Best tile reached | Purged from board | New minimum spawn |
+|-------------------|-------------------|-------------------|
+| 512               | all 2s            | 4 |
+| 1024              | all 4s            | 8 |
+| 2048              | all 8s            | 16 |
+| 4096              | all 16s           | 32 |
+| …                 | next tier         | doubles |
+
+After a purge, gravity collapses and the merge cascade re-runs (purges can chain!).
+
+## 8. Danger & game over
+
+- A column with **≤ 2 free cells** pulses its track border in the theme's danger
+  accent; a full column pulses harder.
+- **Game over** when:
+  1. You fire into a **full column** whose end (bottom-most) tile ≠ current tile, or
+  2. The **board locks**: all 5 columns are full and the current tile matches
+     none of the column-end tiles (every possible shot would be fatal).
+- Firing into a full column whose end tile **matches** is legal — it merges in place.
+
+## 9. Undo
+
+- One free undo per shot (single-step, like Time Attack): restores columns,
+  score, current + next tile from before the last shot. No currency attached.
+
+## 10. Flow & screens
+
+- **Pause** — reuses `GamePauseDialog` (resume / restart / home), back button pauses.
+- **Game over** — themed dialog: final score, best score, best tile, play again / home.
+- Entry from the Main menu as a third `GameModeCard` ("NEON DROP"), portrait and
+  landscape variants, navigation route `dropMerge`.
+
+## 11. Animation inventory
+
+| Event | Animation |
+|-------|-----------|
+| Shot | Tile travels launcher → slot, ease-out, squash on impact |
+| Merge | Consumed tiles fly/fade into target; target pops 1→1.25→1 with radial glow |
+| Collapse | Tiles slide to new rows (spring, slight overshoot) |
+| Combo | Floating "COMBO ×N" text rising over the board |
+| Purge | Purged tiles flash then shrink-fade with glow |
+| Unlock | Banner sweep + tile glow celebration |
+| Danger | Infinite pulse on near-full column borders |
+| Launcher | Idle bob on the current tile; ghost slot soft-pulses |
+
+All timings live in one place (`DropAnim`) so feel can be tuned centrally.
+
+## 12. Settings integration
+
+- Sound uses the existing `SoundManager` (merge / move / game-over cues) gated by
+  `soundEnabledFlow`; haptics gated by `vibrationEnabledFlow` — same behavior as
+  the other modes.
+
+## 13. Architecture
+
+```
+game/DropMergeEngine.kt        pure Kotlin rules — resolve(shot) → list of board
+                               snapshots (steps) with merge metadata; unit-tested
+model/DropMergeModels.kt       DropTile, DropStep, DropMergeState
+data/repository/DropMergeRepository.kt   DataStore: best score / best tile / games
+viewmodel/DropMergeViewModel.kt          plays steps with delays, exposes StateFlow,
+                                         events for sound/haptics, undo, pause
+ui/screens/DropMergeScreen.kt            themed board + launcher + dialogs
+```
+
+The engine emits **snapshot steps**; the ViewModel plays them on a coroutine with
+tuned delays; the UI animates tile ids between snapshots. Logic stays 100%
+testable and animation stays 100% declarative.


### PR DESCRIPTION
Adds a third game mode in the X2-Blocks style (shoot-up number merge), with **no coins, boosters, shop or ads** — pure mechanics and animation, fully skinned by the existing `GameTheme` system.

## Mechanics (full spec in `docs/NEON_DROP_MECHANICS.md`)
- **Board:** 5×8, stacks hang from the top, gravity pulls toward the ceiling; launcher fires tiles upward
- **Merging:** merges with all equal orthogonal neighbors at once — ×2 / ×4 / ×8 multipliers
- **Chains:** gravity collapse → deterministic re-scan → cascades with COMBO ×N flair
- **Spawning:** weighted 5-value window (2…32 at start) that rises with best tile ever
- **Milestones & purge:** unlock badge/banner (256 → 512 → …); reaching 512 detonates all 2s, 1024 the 4s, etc.
- **Game over:** overflow shot into a full non-matching column, or full board lock; danger pulse on near-full columns
- **QoL:** free single-step undo, pause dialog reuse, sound/haptics via existing settings, best score/tile in DataStore

## Architecture
- `game/DropMergeEngine.kt` — pure-Kotlin deterministic rules engine emitting animation snapshot steps
- `viewmodel/DropMergeViewModel.kt` — plays steps on coroutines, exposes StateFlow + feedback events
- `ui/screens/DropMergeScreen.kt` — id-stable tile animations (spring settle, merge pop + glow, consume fly-ins, purge shrink, ghost landing slot, launcher bob), tap or drag-to-aim
- Main-menu cards (portrait + landscape) and `dropMerge` navigation route

## Testing
- ✅ 16 engine unit tests (`DropMergeEngineTest`) — placement, cascades, ×4 merges, gravity chains, overflow, board lock, spawn windows, purges, stable tile ids — all passing
- ⚠️ Compose UI layer not build-verified (sandbox had no Android SDK access) — please run an Assemble in Android Studio before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBdKfjeyd15KNaPecG1KqU