### PR TITLE
Neon Drop: board-capped spawns + first-play tutorial

### DIFF
--- a/app/src/main/java/com/avfusionapps/game_2048/data/gameSettingsDataStore.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/data/gameSettingsDataStore.kt
@@ -27,6 +27,7 @@ class GameSettingsRepository(private val context: Context) {
         val VIBRATION_ENABLED_KEY = booleanPreferencesKey("vibration_enabled")
         val HAS_SEEN_CLASSIC_TUTORIAL_KEY = booleanPreferencesKey("has_seen_classic_tutorial")
         val HAS_SEEN_TIME_ATTACK_TUTORIAL_KEY = booleanPreferencesKey("has_seen_time_attack_tutorial")
+        val HAS_SEEN_NEON_DROP_TUTORIAL_KEY = booleanPreferencesKey("has_seen_neon_drop_tutorial")
         const val DEFAULT_PLAYER_NAME = "Player"
         const val DEFAULT_HIGH_SCORE = 0
     }
@@ -165,6 +166,26 @@ class GameSettingsRepository(private val context: Context) {
     suspend fun updateHasSeenTimeAttackTutorial(hasSeen: Boolean) {
         context.gameSettingsDataStore.edit { preferences ->
             preferences[HAS_SEEN_TIME_ATTACK_TUTORIAL_KEY] = hasSeen
+        }
+    }
+
+    // Flow to check if the Neon Drop guided tutorial has been seen
+    val hasSeenNeonDropTutorialFlow: Flow<Boolean> = context.gameSettingsDataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(androidx.datastore.preferences.core.emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences ->
+            preferences[HAS_SEEN_NEON_DROP_TUTORIAL_KEY] ?: false
+        }
+
+    // Suspending function to update the Neon Drop tutorial seen status
+    suspend fun updateHasSeenNeonDropTutorial(hasSeen: Boolean) {
+        context.gameSettingsDataStore.edit { preferences ->
+            preferences[HAS_SEEN_NEON_DROP_TUTORIAL_KEY] = hasSeen
         }
     }
 }

--- a/app/src/main/java/com/avfusionapps/game_2048/game/DropMergeEngine.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/game/DropMergeEngine.kt
@@ -37,17 +37,39 @@ class DropMergeEngine(
             1 shl (log2(bestTileEver) - 7)
         } else 2
 
-    /** Weighted random spawn from a window of consecutive powers of two. */
-    fun spawnValue(bestTileEver: Int): Int {
-        val minExp = log2(minSpawnValue(bestTileEver))
-        val weights = DropMergeConfig.SPAWN_WEIGHTS
-        val total = weights.sum()
+    /** Highest tile value currently on the board (0 if the board is empty). */
+    fun boardMax(columns: DropColumns): Int =
+        columns.maxOfOrNull { col -> col.maxOfOrNull { it.value } ?: 0 } ?: 0
+
+    /**
+     * Weighted random spawn, **capped so the launcher never offers a tile bigger
+     * than the largest tile currently on the board** — every spawned tile stays
+     * mergeable instead of wasting a lane.
+     *
+     * The window is up to [DropMergeConfig.SPAWN_WINDOW] consecutive powers of two
+     * ending at the board max (so it slides up as the board grows), floored at the
+     * purge floor from the best tile ever. An empty board bootstraps to the floor.
+     *
+     * @param boardMax     highest tile currently on the board (see [boardMax]); 0 if empty
+     * @param bestTileEver drives the purge floor (smallest value worth spawning)
+     */
+    fun spawnValue(boardMax: Int, bestTileEver: Int): Int {
+        val floor = minSpawnValue(bestTileEver)
+        // Never below the floor; empty/low board bootstraps up to the floor.
+        val ceiling = maxOf(floor, boardMax)
+        val topExp = log2(ceiling)
+        val minExp = log2(floor)
+        val botExp = maxOf(minExp, topExp - (DropMergeConfig.SPAWN_WINDOW - 1))
+        val n = topExp - botExp + 1 // number of candidate powers of two (1..SPAWN_WINDOW)
+
+        val weights = DropMergeConfig.SPAWN_WEIGHTS // smallest value weighted heaviest
+        val total = (0 until n).sumOf { weights[it] }
         var pick = random.nextInt(total)
-        for (i in 0 until DropMergeConfig.SPAWN_WINDOW) {
+        for (i in 0 until n) {
             pick -= weights[i]
-            if (pick < 0) return 1 shl (minExp + i)
+            if (pick < 0) return 1 shl (botExp + i)
         }
-        return 1 shl minExp
+        return 1 shl botExp
     }
 
     /** Next milestone shown on the locked badge. */

--- a/app/src/main/java/com/avfusionapps/game_2048/ui/screens/DropMergeScreen.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/ui/screens/DropMergeScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -77,6 +78,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -118,6 +120,27 @@ fun DropMergeScreen(
     val bestScore by viewModel.bestScore.collectAsState(initial = 0)
     val vibrationEnabled by viewModel.vibrationEnabled.collectAsState()
     val soundEnabled by viewModel.soundEnabled.collectAsState()
+
+    // First-play guided tutorial: tips advance as the player takes their first shots.
+    val hasSeenTutorial by viewModel.hasSeenTutorial.collectAsState()
+    var tutorialDismissed by rememberSaveable { mutableStateOf(false) }
+    val tutorialTips = listOf(
+        stringResource(R.string.drop_tut_1),
+        stringResource(R.string.drop_tut_2),
+        stringResource(R.string.drop_tut_3),
+        stringResource(R.string.drop_tut_4),
+        stringResource(R.string.drop_tut_5),
+        stringResource(R.string.drop_tut_6)
+    )
+    val showTutorial = hasSeenTutorial == false && !tutorialDismissed && !gameState.isGameOver
+    val tutorialStep = gameState.moveCount.coerceAtMost(tutorialTips.lastIndex)
+
+    // Mark complete once the player shoots past the last tip.
+    LaunchedEffect(gameState.moveCount, hasSeenTutorial) {
+        if (hasSeenTutorial == false && gameState.moveCount > tutorialTips.lastIndex) {
+            viewModel.setTutorialSeen()
+        }
+    }
 
     val haptics = LocalHapticFeedback.current
     val context = LocalContext.current
@@ -238,6 +261,23 @@ fun DropMergeScreen(
         ) {
             val unlockedValue = gameState.justUnlockedValue ?: 0
             UnlockBanner(value = unlockedValue)
+        }
+
+        // ── First-play guided tutorial coach (advances with the first shots) ──
+        if (showTutorial) {
+            NeonDropTutorial(
+                step = tutorialStep,
+                total = tutorialTips.size,
+                text = tutorialTips[tutorialStep],
+                isLast = tutorialStep == tutorialTips.lastIndex,
+                onFinish = {
+                    tutorialDismissed = true
+                    viewModel.setTutorialSeen()
+                },
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = screenH * 0.135f, start = screenW * 0.06f, end = screenW * 0.06f)
+            )
         }
     }
 
@@ -1303,6 +1343,93 @@ private fun BottomActionPill(
             label, color = accent, fontSize = (height.value * 0.14f).sp,
             fontWeight = FontWeight.Bold, letterSpacing = 0.5.sp, maxLines = 1
         )
+    }
+}
+
+// ──────────────────────────── First-play tutorial ───────────────────────────
+
+/**
+ * Non-blocking coach card shown to first-time players. The tip advances with the
+ * player's own first shots (driven by moveCount), so they learn by doing. A Skip
+ * button (or the final "Got it!") dismisses it.
+ */
+@Composable
+private fun NeonDropTutorial(
+    step: Int,
+    total: Int,
+    text: String,
+    isLast: Boolean,
+    onFinish: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val theme = LocalGameTheme.current
+    val shape = RoundedCornerShape(18.dp)
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(
+                Brush.verticalGradient(
+                    listOf(theme.surfaceColor.copy(alpha = 0.97f), theme.surfaceColor.copy(alpha = 0.88f))
+                )
+            )
+            .border(1.5.dp, theme.accentColor.copy(alpha = 0.6f), shape)
+            .padding(horizontal = 18.dp, vertical = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.drop_how_to_play),
+                color = theme.accentColor,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 1.5.sp,
+                modifier = Modifier.weight(1f)
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically) {
+                repeat(total) { i ->
+                    Box(
+                        Modifier
+                            .size(if (i == step) 8.dp else 6.dp)
+                            .clip(CircleShape)
+                            .background(if (i <= step) theme.accentColor else theme.textColor.copy(alpha = 0.25f))
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(9.dp))
+        Text(
+            text = text,
+            color = theme.textColor,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            lineHeight = 20.sp
+        )
+        Spacer(Modifier.height(11.dp))
+        val btnShape = RoundedCornerShape(50)
+        Box(
+            modifier = Modifier
+                .clip(btnShape)
+                .then(
+                    if (isLast) Modifier.background(theme.accentColor)
+                    else Modifier.border(1.dp, theme.accentColor.copy(alpha = 0.5f), btnShape)
+                )
+                .pointerInput(Unit) { detectTapGestures { onFinish() } }
+                .padding(horizontal = 20.dp, vertical = 7.dp)
+        ) {
+            Text(
+                text = if (isLast) stringResource(R.string.drop_tut_got_it) else stringResource(R.string.drop_tut_skip),
+                color = if (isLast) {
+                    if (theme.accentColor.luminance() > 0.55f) Color(0xFF1E1E2E) else Color.White
+                } else theme.accentColor,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/avfusionapps/game_2048/viewmodel/DropMergeViewModel.kt
+++ b/app/src/main/java/com/avfusionapps/game_2048/viewmodel/DropMergeViewModel.kt
@@ -55,6 +55,14 @@ class DropMergeViewModel(application: Application) : AndroidViewModel(applicatio
     val soundEnabled: StateFlow<Boolean> = settingsRepository.soundEnabledFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
+    // null = not yet loaded (avoids flashing the tutorial before we know).
+    val hasSeenTutorial: StateFlow<Boolean?> = settingsRepository.hasSeenNeonDropTutorialFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    fun setTutorialSeen() {
+        viewModelScope.launch { settingsRepository.updateHasSeenNeonDropTutorial(true) }
+    }
+
     private val _events = MutableSharedFlow<DropGameEvent>(
         replay = 0,
         extraBufferCapacity = 8,
@@ -76,8 +84,9 @@ class DropMergeViewModel(application: Application) : AndroidViewModel(applicatio
         resolveJob?.cancel()
         undoSnapshot = null
         val best = persistedBestTile ?: _gameState.value.bestTileEver
-        val current = engine.spawnValue(best)
-        val next = engine.spawnValue(best)
+        // Fresh board is empty (boardMax 0) → both bootstrap to the small floor.
+        val current = engine.spawnValue(boardMax = 0, bestTileEver = best)
+        val next = engine.spawnValue(boardMax = 0, bestTileEver = best)
         _gameState.value = DropMergeState(
             currentValue = current,
             nextValue = next,
@@ -153,9 +162,13 @@ class DropMergeViewModel(application: Application) : AndroidViewModel(applicatio
                 }
             }
 
-            // Reload the launcher and settle the turn.
+            // Reload the launcher and settle the turn. Cap the next tile at the
+            // just-settled board's max so it's always mergeable.
             val newCurrent = _gameState.value.nextValue
-            val newNext = engine.spawnValue(runningBest)
+            val newNext = engine.spawnValue(
+                boardMax = engine.boardMax(_gameState.value.columns),
+                bestTileEver = runningBest
+            )
             val settled = _gameState.value.copy(
                 isResolving = false,
                 canUndo = true,
@@ -187,7 +200,10 @@ class DropMergeViewModel(application: Application) : AndroidViewModel(applicatio
         _events.tryEmit(DropGameEvent.SKIP)
         _gameState.value = state.copy(
             currentValue = state.nextValue,
-            nextValue = engine.spawnValue(state.bestTileEver),
+            nextValue = engine.spawnValue(
+                boardMax = engine.boardMax(state.columns),
+                bestTileEver = state.bestTileEver
+            ),
             canSkip = false
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,16 @@
     <string name="drop_hud_goal">NEXT GOAL</string>
     <string name="drop_tap_to_shoot">TAP LANE TO SHOOT</string>
     <string name="drop_shoot_to_merge">SHOOT SAME NUMBER TO MERGE</string>
+    <!-- Neon Drop guided tutorial (first play) -->
+    <string name="drop_tut_1">👆 Tap any lane to shoot the tile upward</string>
+    <string name="drop_tut_2">Same numbers that touch MERGE and double — line them up!</string>
+    <string name="drop_tut_3">One shot can chain several merges — that\'s a COMBO!</string>
+    <string name="drop_tut_4">Grow tiles up toward the glowing NEXT-GOAL badge</string>
+    <string name="drop_tut_5">Stuck? UNDO your last shot, or SKIP to swap the tile</string>
+    <string name="drop_tut_6">You\'ve got it — keep chaining merges! 🎉</string>
+    <string name="drop_tut_skip">Skip</string>
+    <string name="drop_tut_got_it">Got it!</string>
+    <string name="drop_how_to_play">HOW TO PLAY</string>
     <string name="best_score">BEST SCORE</string>
     <string name="continue_game">Continue</string>
     <string name="continue_game_subtitle">Pick up where\nyou left off</string>

--- a/app/src/test/java/com/avfusionapps/game_2048/DropMergeEngineTest.kt
+++ b/app/src/test/java/com/avfusionapps/game_2048/DropMergeEngineTest.kt
@@ -164,15 +164,24 @@ class DropMergeEngineTest {
     }
 
     @Test
-    fun `spawn values stay inside the window`() {
+    fun `spawn values stay inside the window and never exceed the board max`() {
         val e = engine()
         repeat(500) {
-            val v = e.spawnValue(bestTileEver = 0)
+            val v = e.spawnValue(boardMax = 32, bestTileEver = 0)
             assertTrue("spawned $v", v in listOf(2, 4, 8, 16, 32))
         }
         repeat(500) {
-            val v = e.spawnValue(bestTileEver = 1024)
+            val v = e.spawnValue(boardMax = 128, bestTileEver = 1024)
             assertTrue("spawned $v", v in listOf(8, 16, 32, 64, 128))
+        }
+        // Never spawn a tile larger than the current board max.
+        repeat(500) {
+            val v = e.spawnValue(boardMax = 8, bestTileEver = 0)
+            assertTrue("spawned $v", v in listOf(2, 4, 8))
+        }
+        // An empty board bootstraps to the floor.
+        repeat(50) {
+            assertEquals(2, e.spawnValue(boardMax = 0, bestTileEver = 0))
         }
     }
 


### PR DESCRIPTION
Two Neon Drop gameplay improvements. **No DB/schema change** (only a new DataStore boolean flag; Room untouched).

## 1. Board-capped spawns
The launcher previously anchored its spawn window to your all-time best tile, so a near-empty board could hand you a tile bigger than anything on it — unmergeable, wasting a lane. Now the spawn ceiling is the **board's current highest tile**: every spawned tile is mergeable. Sliding 5-wide window weighted toward smaller values; empty board bootstraps to the purge-floor. You grow by building intermediates and merging up, with the occasional at-cap tile to double your max.

## 2. First-play guided tutorial
First-time players get a **non-blocking coach** that teaches by doing — tips advance with their own first ~6 shots:
tap to shoot → same numbers merge → chain = combo → reach the next-goal → undo/skip → done. Progress dots + Skip / "Got it!". Shown once, gated by a new `has_seen_neon_drop_tutorial` flag (matches the existing Classic/Time-Attack tutorial pattern).

## Verification
- `compileDebugKotlin` + `assembleDebug` pass; `DropMergeEngineTest` passes (incl. new cap assertions: never spawns above board max, empty board → floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)